### PR TITLE
Use rmeta endpoints

### DIFF
--- a/nginx/lua/tika-response.lua
+++ b/nginx/lua/tika-response.lua
@@ -11,11 +11,11 @@ end
 if eof then
     local whole = table.concat(buffered)
     ngx.ctx.buffered = nil
-    -- TODO parse json here
     local cjson = require "cjson"
     local body = cjson.decode(whole)
+    -- TODO add more response data
     local response = cjson.encode({
-        extracted_text = body["X-TIKA:content"]
+        extracted_text = body[1]["X-TIKA:content"]
     })
     ngx.arg[1] = response
 end

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,7 +27,7 @@ http {
                 -- remove args
                 ngx.req.set_uri_args({local_file_path=nil})
             }
-            proxy_pass http://localhost:9998/tika;
+            proxy_pass http://localhost:9998/rmeta/text;
 
             header_filter_by_lua_block { ngx.header.content_length = nil }
             body_filter_by_lua_file '/app/lua/tika-response.lua';
@@ -35,7 +35,7 @@ http {
 
         location /extract_text/ {
 
-            proxy_pass http://localhost:9998/tika/form;
+            proxy_pass http://localhost:9998/rmeta/form/text;
             client_max_body_size 0;
             
             header_filter_by_lua_block { ngx.header.content_length = nil }


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4577

`/rmeta` is the only endpoint pathing that allows for a consistent file upload AND file pointer response, so switch both endpoints to `/rmeta`.

[rmeta docs](https://cwiki.apache.org/confluence/display/TIKA/TikaServer#TikaServer-RecursiveMetadataandContent)

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
