### PR TITLE
Convert /test to /ping

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -10,10 +10,10 @@ http {
         location / {
             proxy_pass http://localhost:9998/tika;
         }
-        location /test/ {
+        location /ping/ {
             default_type 'text/plain';
             content_by_lua_block {
-                ngx.say('Hello,world!')
+                ngx.say('Running!')
             }
         }
 


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/4576

Rename the `/test` endpoint to `/ping` and return `Running!`.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
