### PR TITLE
Add a release job placeholder

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -1,0 +1,9 @@
+---
+# $yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
+agents:
+  image: "docker.elastic.co/ci-agent-images/drivah:0.18.1"
+
+steps:
+  - label: "placeholder"
+    command: "echo 'this is a placeholder'"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,4 +1,6 @@
 # Declare your Buildkite pipelines below
+
+############################# Branch and PR Test Suite #############################
 ---
 # yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
@@ -28,3 +30,37 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+
+############################# Release Job #############################
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "data-extraction-service-release"
+  description: "Data Extraction Service release"
+  links:
+    - title: "Data Extraction Service Buildkite Jobs"
+      url: "https://buildkite.com/elastic/data-extraction-service"
+spec:
+  type: "buildkite-pipeline"
+  owner: "group:ingestion-team"
+  system: "buildkite"
+  implementation:
+    apiVersion: "buildkite.elastic.dev/v1"
+    kind: "Pipeline"
+    metadata:
+      name: "data-extraction-service-release"
+      description: "Data Extraction Service release"
+      links:
+        - title: "Data Extraction Service Buildkite release Jobs"
+          url: "https://buildkite.com/elastic/data-extraction-service-release"
+    spec:
+      pipeline_file: ".buildkite/release.yml"
+      provider_settings:
+        trigger_mode: "none"
+      repository: "elastic/data-extraction-service"
+      teams:
+        everyone:
+          access_level: "READ_ONLY"
+        ingestion-team:
+          access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
## part of https://github.com/elastic/enterprise-search-team/issues/4578


Related to https://github.com/elastic/data-extraction-service/pull/15, this adds a new job to the catolog-info.yml, so that we can iterate on the actual job's functionality in a separate PR. But this change needs to be merged before buildkite will actually know about and/or run the new job.

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference


## Related Pull Requests

- https://github.com/elastic/data-extraction-service/pull/15

