### PR TITLE
Fix response and cleanup readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,18 @@ $ docker rm extraction-service
 To send a file to be extracted:
 ```zsh
 $ curl -X PUT http://localhost:8090/extract_text/ \
-  --data-binary @/path/to/file.name \
-  -H "Content-Type: application/octet-stream" \
-  -H "Accept: application/json" | jq
+  -T /path/to/file.name
+```
+
+This will return a response like the following:
+```json
+{
+  "extracted_text": "Hello world!",
+  "_meta": {
+    "X-ELASTIC:service": "tika",
+    "X-ELASTIC:TIKA:parsed_by": ["parser1", "parser2"]
+  }
+}
 ```
 
 To extract a file locally, it must first be added to the docker container. You can manually do this using `docker cp` or you can mount a volume to share files with a different system.
@@ -40,7 +49,7 @@ With `docker cp`
 ```sh
 $ docker run -p 8090:8090 -it --name extraction-service extraction-service
 $ docker cp /path/to/file.name extraction-service:/app/files/file.name
-$ curl -X PUT http://localhost:8090/extract_text/?local_file_path=/app/files/file.name -H "Accept: application/json" | jq
+$ curl -X PUT http://localhost:8090/extract_text/?local_file_path=/app/files/file.name | jq
 ```
 
 With volume sharing.
@@ -53,5 +62,4 @@ For volume sharing, `/local/file/location:/app/files` can also be replaced with 
 ## Logging
 
 - Openresty logs: `/var/log/openresty.log`
-- Openresty error logs: `/var/log/openresty_errors.log`
-- Tikaserver java logs: `/var/log/tikaserver.log`
+- Tikaserver java logs: `/var/log/tika.log`

--- a/nginx/lua/tika-response-body.lua
+++ b/nginx/lua/tika-response-body.lua
@@ -13,7 +13,11 @@ if eof then
     ngx.ctx.buffered = nil
 
     local cjson = require "cjson"
-    local response = {}
+    local response = {
+        _meta = {
+            ["X-ELASTIC:service"] = "tika"
+        }
+    }
 
     if ngx.status == 200 then
         local body = cjson.decode(whole)
@@ -42,8 +46,8 @@ if eof then
                 response["extracted_text"] = ""
             end
         else
-            response["parsed_by"] = body["X-TIKA:Parsed-By"]
             response["extracted_text"] = body["X-TIKA:content"]
+            response["_meta"]["X-ELASTIC:TIKA:parsed_by"] = body["X-TIKA:Parsed-By"]
         end
     elseif ngx.status == 422 then
         response["error"] = "Unprocessable Entity"


### PR DESCRIPTION
## Follow up from https://github.com/elastic/data-extraction-service/pull/12

- Restructure the response body to be more service-agnostic
- Cleanup readme and tests

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Ran `make e2e` locally and all tests passed
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
