### PR TITLE
Use archive for download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir /run/openrc\
 
 # get services we need
 RUN apk add --no-cache openrc openjdk8 curl
-RUN wget https://downloads.apache.org/tika/2.8.0/tika-server-standard-2.8.0.jar
+RUN wget https://archive.apache.org/dist/tika/2.8.0/tika-server-standard-2.8.0.jar
 
 # file setup
 COPY runner.sh runner.sh


### PR DESCRIPTION
The endpoint for downloading 2.8.0 doesn't exist anymore at `downloads.apache.org` because it is no longer the latest version. It turns out that with new releases, previous release download URLs are removed. To continue downloading 2.8.0 we must use `archive.apache.org`.