### PR TITLE
Tie docker image to specific version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:alpine
+FROM openresty/openresty:1.21.4.1-0-alpine
 EXPOSE 8090
 
 WORKDIR /app


### PR DESCRIPTION
The docker image should be tied to a specific version. This PR wil set openresty:alpine docker image to the latest version as of this PR.
[See for more info.](https://hub.docker.com/r/openresty/openresty)