### PR TITLE
Update the docker namespace to integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For product documentation and version compatibility, see: [Connectors -> Content
 ## How it works
 
 The artifact producted by this repo is the `data-extraction-service` Docker image.
-See https://www.docker.elastic.co/r/enterprise-search/data-extraction-service for the full list of artifacts/versions.
+See https://www.docker.elastic.co/r/integrations/data-extraction-service for the full list of artifacts/versions.
 
 This docker image runs [openresty](https://openresty.org/en/getting-started.html) and [tika-server](https://cwiki.apache.org/confluence/display/TIKA/TikaServer) as background services, which is handled by [openrc](https://wiki.gentoo.org/wiki/OpenRC).
 
@@ -23,11 +23,11 @@ This docker image runs [openresty](https://openresty.org/en/getting-started.html
 ### Usage
 
 First, pull your image of choice.
-You can find the latest version by looking at https://www.docker.elastic.co/r/enterprise-search/data-extraction-service.
+You can find the latest version by looking at https://www.docker.elastic.co/r/integrations/data-extraction-service.
 
 ```sh
 # replace "<version>" with your selected version
-$ docker pull docker.elastic.co/enterprise-search/data-extraction-service:<version>
+$ docker pull docker.elastic.co/integrations/data-extraction-service:<version>
 ```
 
 Then, start a container from the image with:
@@ -36,7 +36,7 @@ $ docker run \
   -p 8090:8090 \
   -it \
   --name extraction-service \
-  docker.elastic.co/enterprise-search/data-extraction-service:<version>
+  docker.elastic.co/integrations/data-extraction-service:<version>
 ```
 
 You can validate that the service is running with:
@@ -79,7 +79,7 @@ $ docker run \
   -it \
   --name extraction-service \
   -v /local/file/location:/app/files \
-  docker.elastic.co/enterprise-search/data-extraction-service:<version>
+  docker.elastic.co/integrations/data-extraction-service:<version>
 ```
 
 For volume sharing, `/local/file/location:/app/files` can also be replaced with `docker-volume-name:/app/files` if you intend to share files between two docker containers. Check the [docker volume docs](https://docs.docker.com/storage/volumes/) for more details.

--- a/drivah.toml.sh
+++ b/drivah.toml.sh
@@ -6,11 +6,7 @@ VERSION=$(head $VERSION_FILE)
 
 DOCKER_REPO="docker.elastic.co"
 
-if [[ "$VERSION" == *-SNAPSHOT ]]; then
-  DOCKER_NAMESPACE="swiftype"
-else
-  DOCKER_NAMESPACE="enterprise-search"
-fi
+DOCKER_NAMESPACE="integrations"
 DOCKER_PROJECT_NAME="data-extraction-service"
 DOCKER_IMAGE_BASE="${DOCKER_REPO}/${DOCKER_NAMESPACE}/${DOCKER_PROJECT_NAME}"
 

--- a/drivah.toml.sh
+++ b/drivah.toml.sh
@@ -10,9 +10,12 @@ DOCKER_NAMESPACE="integrations"
 DOCKER_PROJECT_NAME="data-extraction-service"
 DOCKER_IMAGE_BASE="${DOCKER_REPO}/${DOCKER_NAMESPACE}/${DOCKER_PROJECT_NAME}"
 
+# We will continue to build and push image to namespace enterprise-search in 8.16 and 8.17
+TEMP_DOCKER_NAMESPACE="enterprise-search"
+TEMP_DOCKER_IMAGE_BASE="${DOCKER_REPO}/${TEMP_DOCKER_NAMESPACE}/${DOCKER_PROJECT_NAME}"
 
 cat <<EOF
 [container.image]
-names = ["${DOCKER_IMAGE_BASE}"]
+names = ["${DOCKER_IMAGE_BASE}", "${TEMP_DOCKER_IMAGE_BASE}"]
 tags = ["${VERSION}"]
 EOF


### PR DESCRIPTION
## Part of https://github.com/elastic/search-team/issues/7481

This PR updates the docker namespace to `integrations`.

It will continue to build and push docker image to namespace `enterprise-search` for 8.16 and 8.17.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Ran `make e2e` locally and all tests passed
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes