### PR TITLE
Rename the ingestion-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global rule
-*    @elastic/ingestion-team
+*    @elastic/search-extract-and-transform

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,7 +13,7 @@ metadata:
       url: https://buildkite.com/elastic/data-extraction-service
 spec:
   type: buildkite-pipeline
-  owner: group:ingestion-team
+  owner: group:search-extract-and-transform
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -25,7 +25,7 @@ spec:
       repository: elastic/data-extraction-service
       pipeline_file: ".buildkite/pipeline.yml"
       teams:
-        ingestion-team:
+        search-extract-and-transform:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
@@ -42,7 +42,7 @@ metadata:
       url: "https://buildkite.com/elastic/data-extraction-service-release"
 spec:
   type: "buildkite-pipeline"
-  owner: "group:ingestion-team"
+  owner: "group:search-extract-and-transform"
   system: "buildkite"
   implementation:
     apiVersion: "buildkite.elastic.dev/v1"
@@ -61,5 +61,5 @@ spec:
       teams:
         everyone:
           access_level: "READ_ONLY"
-        ingestion-team:
+        search-extract-and-transform:
           access_level: MANAGE_BUILD_AND_READ

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Enhancements that can be done after your initial contribution:
 
 To make sure we're building a great Extraction Service, we will be pretty strict on this checklist, and we will not allow changes
 
-If you need changes in the API contract, or you are not sure about how to do something, reach out to the [Ingestion team](https://github.com/orgs/elastic/teams/ingestion-team/members) and/or file an issue.
+If you need changes in the API contract, or you are not sure about how to do something, reach out to the [Ingestion team](https://github.com/orgs/elastic/teams/search-extract-and-transform/members) and/or file an issue.
 
 
 ### Adhering to the API contract


### PR DESCRIPTION
### Description
As part of the GitHub teams renaming initiative, it's required to rename the @elastic/ingestion-team to @elastic/search-extract-and-transform.

This PR is dedicated to renaming @elastic/ingestion-team to @elastic/search-extract-and-transform 