### PR TITLE
[0.3] Merge pull request #42 from elastic/chenhui/update-docker-namespace

### DIFF
--- a/drivah.toml.sh
+++ b/drivah.toml.sh
@@ -6,11 +6,7 @@ VERSION=$(head $VERSION_FILE)
 
 DOCKER_REPO="docker.elastic.co"
 
-if [[ "$VERSION" == *-SNAPSHOT ]]; then
-  DOCKER_NAMESPACE="swiftype"
-else
-  DOCKER_NAMESPACE="enterprise-search"
-fi
+DOCKER_NAMESPACE="integrations"
 DOCKER_PROJECT_NAME="data-extraction-service"
 DOCKER_IMAGE_BASE="${DOCKER_REPO}/${DOCKER_NAMESPACE}/${DOCKER_PROJECT_NAME}"
 

--- a/drivah.toml.sh
+++ b/drivah.toml.sh
@@ -10,9 +10,12 @@ DOCKER_NAMESPACE="integrations"
 DOCKER_PROJECT_NAME="data-extraction-service"
 DOCKER_IMAGE_BASE="${DOCKER_REPO}/${DOCKER_NAMESPACE}/${DOCKER_PROJECT_NAME}"
 
+# We will continue to build and push image to namespace enterprise-search in 8.16 and 8.17
+TEMP_DOCKER_NAMESPACE="enterprise-search"
+TEMP_DOCKER_IMAGE_BASE="${DOCKER_REPO}/${TEMP_DOCKER_NAMESPACE}/${DOCKER_PROJECT_NAME}"
 
 cat <<EOF
 [container.image]
-names = ["${DOCKER_IMAGE_BASE}"]
+names = ["${DOCKER_IMAGE_BASE}", "${TEMP_DOCKER_IMAGE_BASE}"]
 tags = ["${VERSION}"]
 EOF


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `0.3`:
 - [Merge pull request #42 from elastic/chenhui/update-docker-namespace](https://github.com/elastic/data-extraction-service/pull/42)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)