### PR TITLE
Only release to integrations namespace

### DIFF
--- a/drivah.toml.sh
+++ b/drivah.toml.sh
@@ -10,12 +10,9 @@ DOCKER_NAMESPACE="integrations"
 DOCKER_PROJECT_NAME="data-extraction-service"
 DOCKER_IMAGE_BASE="${DOCKER_REPO}/${DOCKER_NAMESPACE}/${DOCKER_PROJECT_NAME}"
 
-# We will continue to build and push image to namespace enterprise-search in 8.16 and 8.17
-TEMP_DOCKER_NAMESPACE="enterprise-search"
-TEMP_DOCKER_IMAGE_BASE="${DOCKER_REPO}/${TEMP_DOCKER_NAMESPACE}/${DOCKER_PROJECT_NAME}"
 
 cat <<EOF
 [container.image]
-names = ["${DOCKER_IMAGE_BASE}", "${TEMP_DOCKER_IMAGE_BASE}"]
+names = ["${DOCKER_IMAGE_BASE}"]
 tags = ["${VERSION}"]
 EOF


### PR DESCRIPTION
## Part of https://github.com/elastic/search-team/issues/7481

With the backport PR https://github.com/elastic/data-extraction-service/pull/44, release `0.3.x` will push docker images to both `enterprise-search` and `integrations` namespaces.

All releases starting from `0.4` will only push docker images to `integrations` namespace.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Ran `make e2e` locally and all tests passed
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)