### PR TITLE
[0.3] Merge pull request #56 from elastic/bump-tika-to-3.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN mkdir /run/openrc\
   && touch /run/openrc/softlevel
 
 # get services we need
-RUN apk add --no-cache openrc openjdk8 curl
-RUN wget https://archive.apache.org/dist/tika/2.8.0/tika-server-standard-2.8.0.jar
+RUN apk add --no-cache openrc openjdk17-jre-headless curl
+RUN wget https://archive.apache.org/dist/tika/3.2.2/tika-server-standard-3.2.2.jar
 
 # file setup
 COPY runner.sh runner.sh

--- a/openrc/tika
+++ b/openrc/tika
@@ -1,7 +1,7 @@
 #!/sbin/openrc-run
 
 command="java"
-command_args="-jar -Dlog4j.configurationFile=/app/log4j2.xml /app/tika-server-standard-2.8.0.jar
+command_args="-jar -Dlog4j.configurationFile=/app/log4j2.xml /app/tika-server-standard-3.2.2.jar
               --config /app/tika-config.xml"
 command_background=true
 pidfile="/var/run/${RC_SVCNAME}.pid"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `0.3`:
 - [Merge pull request #56 from elastic/bump-tika-to-3.2.2](https://github.com/elastic/data-extraction-service/pull/56)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)