### PR TITLE
Zap previous service state on container startup

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+# Clear OpenRC crashed/started state to allow fresh start
+rc-service tika zap 2>/dev/null || true
+rc-service openresty zap 2>/dev/null || true
+
 echo "Service 'All': Status"
 rc-status -a
 rc-update add tika boot


### PR DESCRIPTION
## Closes https://github.com/elastic/data-extraction-service/issues/63

It was reported that if you:
1. started the extraction service
2. used `docker stop` or Docker Desktop's UI to stop the container
3. attempted to restart the container

that the Data Extraction Service would complain that Tika and OpenResty were both crashed. Web traffic would be refused.

This change introduces a `zap` at container startup that will clear previous state of both services in the container, letting them start back up fresh.

Tested locally with:
1. `docker build -t extraction-service .`
2. `docker run -p 8090:8090 -it --name extraction-service extraction-service:latest`
3. stop from Docker Desktop
4. restart from Docker Desktop
5. validate connection not refused with `curl -v http://localhost:8090/ping`

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Ran `make e2e` locally and all tests passed
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)


## Release Note

Fixes a bug where Docker Containers stopped with `docker stop` or Docker Desktop's stop button could not be restarted to a healthy state.
