### PR TITLE
docs: update security url to link to central policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://discuss.elastic.co/c/enterprise-search/workplace-search/
     about: Please ask and answer questions here.
   - name: Security Vulnerability
-    url: https://www.elastic.co/community/security
+    url: https://github.com/elastic/.github/blob/main/SECURITY.md
     about: DO NOT file issues related to security. Instead, please follow our security policy here.


### PR DESCRIPTION
This PR replaces security URLs with a link to the central security policy.