### PR TITLE
Fix builds for forks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,4 +13,9 @@ notify:
 
 steps:
   - label: ":whale: Build docker image"
+    if: 'build.branch !~ /^((main)|([0-9]+\.[0-9]+))\$/'
     command: "scripts/build-and-publish-docker-image.sh"
+
+  - label: ":whale: Build and publish docker image"
+    if: 'build.branch =~ /^((main)|([0-9]+\.[0-9]+))\$/'
+    command: "scripts/build-and-publish-docker-image.sh --push"

--- a/scripts/build-and-publish-docker-image.sh
+++ b/scripts/build-and-publish-docker-image.sh
@@ -1,17 +1,29 @@
 #!/bin/bash
+#
+# Build the Docker image, optionally publishing it.
+# Usage: build-and-publish-docker-image.sh [--push]
+#
 
 set -ex
 
-source scripts/git-setup.sh
+PUSH=false
+if [[ "$1" == "--push" ]]; then
+  PUSH=true
+fi
 
-VAULT_ADDR=${VAULT_ADDR:-https://vault-ci-prod.elastic.dev}
-VAULT_USER="docker-swiftypeadmin"
-echo "Fetching Docker credentials for '$VAULT_USER' from Vault..."
-DOCKER_USER=$(vault read -address "${VAULT_ADDR}" -field user_20230609 secret/ci/elastic-data-extraction-service/${VAULT_USER})
+if [[ "$PUSH" == "true" ]]; then
+  VAULT_ADDR=${VAULT_ADDR:-https://vault-ci-prod.elastic.dev}
+  VAULT_USER="docker-swiftypeadmin"
+  echo "Fetching Docker credentials for '$VAULT_USER' from Vault..."
+  DOCKER_USER=$(vault read -address "${VAULT_ADDR}" -field user_20230609 secret/ci/elastic-data-extraction-service/${VAULT_USER})
 
-echo "Logging into docker..."
-vault read -address "${VAULT_ADDR}" -field secret_20230609 secret/ci/elastic-data-extraction-service/${VAULT_USER} | \
-  buildah login --username="${DOCKER_USER}" --password-stdin docker.elastic.co
+  echo "Logging into docker..."
+  vault read -address "${VAULT_ADDR}" -field secret_20230609 secret/ci/elastic-data-extraction-service/${VAULT_USER} | \
+    buildah login --username="${DOCKER_USER}" --password-stdin docker.elastic.co
 
-echo "Building and publishing the docker image..."
-drivah build --push .
+  echo "Building and publishing the docker image..."
+  drivah build --push .
+else
+  echo "Building the docker image..."
+  drivah build .
+fi


### PR DESCRIPTION
## Relates to https://github.com/elastic/data-extraction-service/pull/70

The linked PR's CI was failing with:
```
$ ./scripts/build-and-publish-docker-image.sh
--
+ source scripts/git-setup.sh
++ set -ex
++ export GIT_BRANCH=tballison:tallison/bump-tika-3.2.3
++ GIT_BRANCH=tballison:tallison/bump-tika-3.2.3
++ git switch -
Warning: you are leaving 2 commits behind, not connected to
any of your branches:
 
4f339ae Merge branch 'main' into tallison/bump-tika-3.2.3
a19e335 bump tika to 3.2.3 - Fixes bug in XFA PDF parsing.
 
If you want to keep them by creating a new branch, this may be a good time
to do so with:
 
git branch <new-branch-name> 4f339ae
 
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
++ git checkout tballison:tallison/bump-tika-3.2.3
error: pathspec 'tballison:tallison/bump-tika-3.2.3' did not match any file(s) known to git
🚨 Error: The command exited with status 1
```

This is because our `setup-git.sh` script assumes that the buildkite branch is a branch name you can check out (it's not for forks). 

But we don't even need to run this setup-git.sh for PR builds - that's just for releases.

Also - we probably don't need to be publishing SNAPSHOT images for PRs. That should be limited to our maintenance branches. So this makes the `--push` depend on which branch we're building. 

## Checklists



#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

